### PR TITLE
Implement initial dns seedlist discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,11 +594,13 @@ The goal is to to be compliant with most of the [official MongoDB set of specifi
 - https://github.com/mongodb/specifications/blob/master/source/retryable-writes/retryable-writes.rst
 - https://github.com/mongodb/specifications/blob/master/source/retryable-reads/retryable-reads.rst
 - https://github.com/mongodb/specifications/tree/master/source/causal-consistency
+- https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery
 
 **⏳Next**
 
 The following specifications are to be implemented next:
 
+- https://github.com/mongodb/specifications/blob/master/source/polling-srv-records-for-mongos-discovery
 - https://github.com/mongodb/specifications/tree/master/source/transactions
 - https://github.com/mongodb/specifications/tree/master/source/compression
 

--- a/shard.yml
+++ b/shard.yml
@@ -14,6 +14,9 @@ dependencies:
     version: ~> 0.3.0
   db:
     github: crystal-lang/crystal-db
+  durian:
+    github: 636f7374/durian.cr
+    version: ~> 0.1.5
 
 development_dependencies:
   ameba:

--- a/src/cryomongo/client.cr
+++ b/src/cryomongo/client.cr
@@ -219,7 +219,8 @@ class Mongo::Client
     server_description : SDAM::ServerDescription? = nil,
     session : Session::ClientSession? = nil,
     operation_id : Int64? = nil,
-    **args)
+    **args
+  )
     self.command(cmd, write_concern, read_concern, read_preference, server_description, session, operation_id, **args) { |result|
       result
     }
@@ -697,9 +698,9 @@ class Mongo::Client
       topology.update(server_description, new_description)
       server_description.update(new_description)
       connection
-      rescue e
-        connection.try &.close
-        raise e
+    rescue e
+      connection.try &.close
+      raise e
     end
     @pools[server_description.address].checkout
   end
@@ -727,7 +728,7 @@ class Mongo::Client
     loop do
       select
       when @topology_update.send nil
-      # Fiber.yield
+        # Fiber.yield
       else
         break
       end

--- a/src/cryomongo/collection.cr
+++ b/src/cryomongo/collection.cr
@@ -243,7 +243,7 @@ class Mongo::Collection
         limit: limit,
         session: session
       )
-  }.not_nil!
+    }.not_nil!
   end
 
   # Finds the document matching the model.

--- a/src/cryomongo/sdam/monitor.cr
+++ b/src/cryomongo/sdam/monitor.cr
@@ -54,7 +54,7 @@ module Mongo::SDAM
 
         select
         when resume_scan.receive
-        # Immediate scan requested
+          # Immediate scan requested
           sleep(before_cooldown - Time.utc) if Time.utc < before_cooldown
         when timeout @heartbeat_frequency
         end
@@ -69,7 +69,7 @@ module Mongo::SDAM
     def request_immediate_scan
       select
       when resume_scan.send nil
-      # Fiber.yield
+        # Fiber.yield
       else # Ignore - scan is in progress already
       end
     end

--- a/src/cryomongo/sdam/server_description.cr
+++ b/src/cryomongo/sdam/server_description.cr
@@ -114,8 +114,8 @@ class Mongo::SDAM::ServerDescription
   end
 
   def_equals @address, @error, @type, @min_wire_version, @max_wire_version,
-   @me, @hosts, @passives, @arbiters, @tags, @set_name, @set_version, @election_id,
-   @primary, @logical_session_timeout_minutes, @topology_version
+    @me, @hosts, @passives, @arbiters, @tags, @set_name, @set_version, @election_id,
+    @primary, @logical_session_timeout_minutes, @topology_version
 
   def data_bearing?
     @type.mongos? || @type.rs_primary? || @type.rs_secondary? || @type.standalone?

--- a/src/cryomongo/uri/options.cr
+++ b/src/cryomongo/uri/options.cr
@@ -1,3 +1,5 @@
+require "durian"
+
 # A set of options used to configure the driver.
 #
 # NOTE: [For more details, see the uri options specification document](https://github.com/mongodb/specifications/blob/master/source/uri-options/uri-options.rst).
@@ -11,7 +13,7 @@ struct Mongo::Options
   # Additional options provided for authentication (e.g. to enable hostname canonicalization for GSSAPI)
   getter auth_mechanism_properties : String? = nil
   # The database that connections should authenticate against
-  getter auth_source : String? = nil
+  property auth_source : String? = nil
   # The list of allowed compression types for wire protocol messages sent or received from the server
   getter compressors : String? = nil
   # Amount of time to wait for a single TCP socket connection to the server to be established before erroring; note that this applies to SDAM isMaster operations
@@ -39,7 +41,7 @@ struct Mongo::Options
   # Default read preference tags for the client; only valid if the read preference mode is not primary
   getter read_preference_tags : Array(String) = [] of String
   # The name of the replica set to connect to
-  getter replica_set : String? = nil
+  property replica_set : String? = nil
   # Enables retryable reads on server 3.6+
   getter retry_reads : Bool? = true
   # Enables retryable writes on server 3.6+
@@ -51,7 +53,7 @@ struct Mongo::Options
   # Amount of time spent attempting to send or receive on a socket before timing out; note that this only applies to application operations, not SDAM
   getter socket_timeout : Time::Span? = nil
   # Alias of "tls"; required to ensure that Atlas connection strings continue to work
-  getter ssl : Bool? = nil
+  property ssl : Bool? = nil
   # Whether or not to require TLS for connections to the server
   getter tls : Bool? = nil
   # Specifies whether or not the driver should error when the server’s TLS certificate is invalid
@@ -78,6 +80,19 @@ struct Mongo::Options
   getter w_timeout : Time::Span? = nil
   # Specifies the level of compression when using zlib to compress wire protocol messages; -1 signifies the default level, 0 signifies no compression, 1 signifies the fastest speed, and 9 signifies the best compression
   getter zlib_compression_level : Int32? = nil
+
+  # Use custom dns resolver.
+  # Non-standard.
+  #
+  # By default, the Cloudflare public DNS is used. (`1.1.1.1`)
+  getter dns_resolver : Durian::Resolver = begin
+    Durian::Resolver.new.tap { |resolver|
+      resolver.dnsServers = [
+        Durian::Resolver::Server.new ipAddress: Socket::IPAddress.new("1.1.1.1", 53_i32),
+      ]
+      resolver.record_cache = Durian::Cache::Record.new
+    }
+  end
 
   getter! raw : HTTP::Params
 

--- a/src/cryomongo/uri/srv.cr
+++ b/src/cryomongo/uri/srv.cr
@@ -1,0 +1,47 @@
+require "durian"
+
+class Mongo::SRV
+  def initialize(@resolver : Durian::Resolver, @url : String)
+  end
+
+  def resolve
+    hostname, domainname = @url.split(".", 2)
+    if !domainname.includes?('.')
+      raise Mongo::Error.new("Top Level Domain is missing: #{domainname}")
+    end
+
+    srv_records = [] of Durian::Record::SRV
+    txt_record : Durian::Record::TXT? = nil
+
+    @resolver.resolve "_mongodb._tcp.#{hostname}.#{domainname}", [Durian::RecordFlag::SRV] do |response|
+      response[0]?.try &.[2]?.try &.[0]?.try { |packet|
+        srv_records = packet.answers.map &.resourceRecord.as(Durian::Record::SRV)
+        packet.answers.each { |answer|
+          srv_record = answer.resourceRecord.as(Durian::Record::SRV)
+          if srv_record.target.split(".", 2)[1] != domainname
+            raise Mongo::Error.new("SRV record has an invalid domain name: #{srv_record.target}")
+          end
+          srv_records << srv_record
+        }
+      }
+    end
+
+    @resolver.resolve "#{hostname}.#{domainname}", [Durian::RecordFlag::TXT] do |response|
+      response[0]?.try &.[2]?.try &.[0]?.try { |packet|
+        if packet.answers.size > 1
+          raise Mongo::Error.new("#{packet.answers.size} TXT records were found when querying the DNS, but a single record is supported.")
+        else
+          txt_record = packet.answers.[0]?.try &.resourceRecord.as(Durian::Record::TXT)
+        end
+      }
+    end
+
+    @resolver.run
+
+    if srv_records.empty?
+      raise Mongo::Error.new("No SRV records found when querying url: #{@url}")
+    end
+
+    {srv_records, txt_record}
+  end
+end


### PR DESCRIPTION
See: https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery

Added support for the `mongodb+srv` uri scheme.