### PR TITLE
Enable TCP_NODELAY for MongoDB socket connection

### DIFF
--- a/src/cryomongo/connection/connection.cr
+++ b/src/cryomongo/connection/connection.cr
@@ -16,6 +16,7 @@ struct Mongo::Connection
       split = @server_description.address.split(':')
       host = split[0]
       socket = TCPSocket.new(split[0], split[1]? || 27017)
+      socket.tcp_nodelay = true
     end
 
     if @options.ssl || @options.tls


### PR DESCRIPTION
**Problem**

Nagle's algorithm (enabled by default on TCP sockets) buffers small outgoing packets for up to ~40ms before sending them, waiting to see if more data will be written. This is devastating for request/response protocols like MongoDB's wire protocol, where the client sends a small command and immediately waits for a response.

This results in an ~80ms latency penalty per query compared to the expected ~1-2ms.

**Fix**

Set tcp_nodelay = true on the TCP socket after creation in Connection#initialize, which disables Nagle's algorithm.

This is a one-line change in src/cryomongo/connection/connection.cr:

```crystal
  socket = TCPSocket.new(split[0], split[1]? || 27017)
  socket.tcp_nodelay = true
```

**Benchmark**

Tested with a GraphQL API backed by cryomongo, running the same query 50 times against a local MongoDB instance:

|                       |    Before  |    After |
| ----------------- | ------------- |-----------|
| Avg latency |     85ms    | 1.2ms |
| Min latency |     80ms    | 1.0ms |

That's a ~70x improvement.

**Context**

Every major MongoDB driver enables TCP_NODELAY by default:
  - Node.js driver — noDelay: true
  - Ruby driver — TCP_NODELAY
  - Go driver — SetNoDelay(true)
  - Rust driver — set_nodelay(true)